### PR TITLE
fix(lib): fix exception unboundlocalerror

### DIFF
--- a/pythonlib/camoufox/ip.py
+++ b/pythonlib/camoufox/ip.py
@@ -115,6 +115,7 @@ def public_ip(proxy: Optional[str] = None) -> str:
             ip = resp.text.strip()
             validate_ip(ip)
             return ip
-        except (requests.exceptions.ProxyError, requests.RequestException, InvalidIP) as exception:
-            pass
+        except (requests.exceptions.ProxyError, requests.RequestException, InvalidIP) as e:
+            exception = e
+
     raise InvalidIP(f"Failed to get IP address: {exception}")

--- a/upstream.sh
+++ b/upstream.sh
@@ -1,4 +1,4 @@
 version=142.0.1
-release=fork.26
+release=wiremind.26
 closedsrc_rev=1.0.0
 ff_commit=361373160356d92cb5cd4d67783a3806c776ee78  # Playwright Firefox 142 base commit


### PR DESCRIPTION
exception variable is reused locally inside except block which doesn't modify 'exception' declared before the block