### PR TITLE
Fix inaccurate humanized mouse movement

### DIFF
--- a/additions/juggler/protocol/PageHandler.js
+++ b/additions/juggler/protocol/PageHandler.js
@@ -545,7 +545,7 @@ export class PageHandler {
       for (const type of types) {
         if (type === 'mousemove' && ChromeUtils.camouGetBool('humanize', false)) {
           let trajectory = ChromeUtils.camouGetMouseTrajectory(this._lastTrackedPos.x, this._lastTrackedPos.y, x, y);
-          for (let i = 2; i < trajectory.length - 2; i += 2) {
+          for (let i = 2; i < trajectory.length; i += 2) {
             let currentX = trajectory[i];
             let currentY = trajectory[i + 1];
             // Skip movement that is out of bounds


### PR DESCRIPTION
Previously when humanization was enabled `page.mouse.move()` would stop just short of the intended location. This was due to the last movement step in the mouse trajectory being skipped. I could not find any reason for the skipping of the last movement step and removed it.